### PR TITLE
AR-192 remove eval

### DIFF
--- a/lib/pry-byebug/commands/breakpoint.rb
+++ b/lib/pry-byebug/commands/breakpoint.rb
@@ -124,7 +124,7 @@ module PryByebug
         if Regexp.last_match[1].strip.empty?
           errmsg = "Method name declaration valid only in a file context."
           PryByebug.check_file_context(target, errmsg)
-          place = target.eval("self.class.to_s") + place
+          place = target.self.class + place
         end
         breakpoints.add_method(place, condition)
       else

--- a/lib/pry-byebug/helpers/location.rb
+++ b/lib/pry-byebug/helpers/location.rb
@@ -16,8 +16,7 @@ module PryByebug
         # Guard clause for Ruby >= 2.6 providing now Binding#source_location ...
         return source.source_location[0] if source.respond_to?(:source_location)
 
-        # ... to avoid warning: 'eval may not return location in binding'
-        source.eval("__FILE__")
+        __FILE__
       end
     end
   end


### PR DESCRIPTION
AR-192_remove_eval avoided the use of eval with appropriate substitutions